### PR TITLE
Made Morphing Tool display the mod name instead of the lowercase mod ID.

### DIFF
--- a/src/main/java/vazkii/morphtool/ItemMorphTool.java
+++ b/src/main/java/vazkii/morphtool/ItemMorphTool.java
@@ -61,7 +61,7 @@ public class ItemMorphTool extends Item {
 					if(modStack.hasTagCompound() && modStack.getTagCompound().hasKey(MorphingHandler.TAG_MORPH_TOOL_DISPLAY_NAME))
 						name = modStack.getTagCompound().getString(MorphingHandler.TAG_MORPH_TOOL_DISPLAY_NAME);
 
-					tooltip.add(" " + s + " : " + name);
+					tooltip.add(" " + MorphingHandler.getModNameForId(s) + " : " + name);
 				}
 			}
 		}

--- a/src/main/java/vazkii/morphtool/MorphingHandler.java
+++ b/src/main/java/vazkii/morphtool/MorphingHandler.java
@@ -13,7 +13,13 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 public final class MorphingHandler {
 
@@ -152,6 +158,18 @@ public final class MorphingHandler {
 
 		stack.stackSize = 1;
 		return stack;
+	}
+
+	private static final Map<String, String> modNames = new HashMap<String, String>();
+
+	static {
+		for(Map.Entry<String, ModContainer> modEntry : Loader.instance().getIndexedModList().entrySet())
+			modNames.put(modEntry.getKey().toLowerCase(Locale.ENGLISH),  modEntry.getValue().getName());
+	}
+
+	public static String getModNameForId(String modId) {
+		modId = modId.toLowerCase(Locale.ENGLISH);
+		return modNames.containsKey(modId) ? modNames.get(modId) : modId;
 	}
 
 	public static boolean isMorphTool(ItemStack stack) {


### PR DESCRIPTION
Only for display. Internally it's still the mod ID being stored so everything works like it did before, it's just nicer to look at the tooltip.