### PR TITLE
Added option to only morph in the offhand

### DIFF
--- a/src/main/java/vazkii/morphtool/ConfigHandler.java
+++ b/src/main/java/vazkii/morphtool/ConfigHandler.java
@@ -16,7 +16,7 @@ public class ConfigHandler {
 
 	public static Configuration config;
 
-	public static boolean allItems;
+	public static boolean allItems, offHand;
 	public static List<String> whitelistedItems, whitelistedNames, blacklistedMods;
 
 	public static Map<String, String> aliases = new HashMap();
@@ -36,6 +36,8 @@ public class ConfigHandler {
 		whitelistedItems = loadPropStringList("Whitelisted Items", "botania:twigWand", "appliedenergistics2:ToolNetworkTool");
 		whitelistedNames = loadPropStringList("Whitelisted Names", "wrench", "screwdriver", "hammer", "rotator");
 		blacklistedMods = loadPropStringList("Blacklisted Mods", "tconstruct", "intangible");
+		
+		offHand = loadPropBool("Only morphs in offhand", false);
 
 		aliases.clear();
 		List<String> aliasesList = loadPropStringList("Mod Aliases", "botanicaladdons=botania", "ThermalDynamics=ThermalExpansion", "rftoolsdim=rftools");

--- a/src/main/java/vazkii/morphtool/MorphingHandler.java
+++ b/src/main/java/vazkii/morphtool/MorphingHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.RayTraceResult;
@@ -35,23 +36,43 @@ public final class MorphingHandler {
 	public void onPlayerTick(LivingUpdateEvent event) {
 		if(event.getEntity() instanceof EntityPlayer) {
 			EntityPlayer player = (EntityPlayer) event.getEntity();
-			ItemStack mainHandItem = player.getHeldItemMainhand();
+			
+			if(!ConfigHandler.offHand){
+				ItemStack handItem = player.getHeldItemMainhand();
+				if(isMorphTool(handItem)) {
+					RayTraceResult res = raycast(player, 4.5);
+					if(res != null) {
+						IBlockState state = player.worldObj.getBlockState(res.getBlockPos());
+						String mod = getModFromState(state);
 
-			if(isMorphTool(mainHandItem)) {
-				RayTraceResult res = raycast(player, 4.5);
-				if(res != null) {
-					IBlockState state = player.worldObj.getBlockState(res.getBlockPos());
-					String mod = getModFromState(state);
-
-					ItemStack newStack = getShiftStackForMod(mainHandItem, mod);
-					if(newStack != mainHandItem && !ItemStack.areItemsEqual(newStack, mainHandItem)) {
-						player.inventory.setInventorySlotContents(player.inventory.currentItem, newStack);
-						MorphTool.proxy.updateEquippedItem();
+						ItemStack newStack = getShiftStackForMod(handItem, mod);
+						if(newStack != handItem && !ItemStack.areItemsEqual(newStack, handItem)) {
+							player.inventory.setInventorySlotContents(player.inventory.currentItem, newStack);
+							MorphTool.proxy.updateEquippedItem();
+						}
 					}
 				}
 			}
-		}
-	}
+			
+			if(ConfigHandler.offHand){
+				ItemStack handItem = player.getHeldItemOffhand();
+				if(isMorphTool(handItem)) {
+					RayTraceResult res = raycast(player, 4.5);
+					if(res != null) {
+						IBlockState state = player.worldObj.getBlockState(res.getBlockPos());
+						String mod = getModFromState(state);
+
+						ItemStack newStack = getShiftStackForMod(handItem, mod);
+						if(newStack != handItem && !ItemStack.areItemsEqual(newStack, handItem)) {
+							player.setItemStackToSlot(EntityEquipmentSlot.OFFHAND, newStack);						
+							MorphTool.proxy.updateEquippedItem();
+					    }
+						}
+					}
+				}
+			}
+			
+			}
 
 	@SubscribeEvent
 	public void onItemDropped(ItemTossEvent event) {

--- a/src/main/java/vazkii/morphtool/proxy/ClientProxy.java
+++ b/src/main/java/vazkii/morphtool/proxy/ClientProxy.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.util.EnumHand;
 import net.minecraftforge.client.model.ModelLoader;
+import vazkii.morphtool.ConfigHandler;
 import vazkii.morphtool.MorphTool;
 
 public class ClientProxy extends CommonProxy {
@@ -15,7 +16,12 @@ public class ClientProxy extends CommonProxy {
 
 	@Override
 	public void updateEquippedItem() {
-		Minecraft.getMinecraft().entityRenderer.itemRenderer.resetEquippedProgress(EnumHand.MAIN_HAND);
+		if(!ConfigHandler.offHand){
+		    Minecraft.getMinecraft().entityRenderer.itemRenderer.resetEquippedProgress(EnumHand.MAIN_HAND);
+		} 
+		if(ConfigHandler.offHand){
+			Minecraft.getMinecraft().entityRenderer.itemRenderer.resetEquippedProgress(EnumHand.OFF_HAND);	
+		}
 	}
 
 }


### PR DESCRIPTION
I saw the suggestion #11 and made a simple config option to only morph in the offhand.
This improves usage with some wrenches like the Yeta Wrench from EnderIO and the overlay function of it.